### PR TITLE
Fix: 사용자 검색 값 없을때 예외처리 수정

### DIFF
--- a/src/main/java/com/likelion/hufsting/domain/Member/service/MemberInfoService.java
+++ b/src/main/java/com/likelion/hufsting/domain/Member/service/MemberInfoService.java
@@ -8,6 +8,7 @@ import com.likelion.hufsting.domain.Member.repository.MemberRepository;
 import com.likelion.hufsting.domain.follow.service.FollowService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.likelion.hufsting.domain.Member.repository.query.MemberQueryRepository;
@@ -34,16 +35,21 @@ public class MemberInfoService {
         } else {
             finalEmail = email;
         }
-        Member member = memberRepository.findByEmail(finalEmail)
-                .orElseThrow(() -> new IllegalArgumentException("not found: " + finalEmail));
-        boolean isFollowingResponse = isFollowing(authentication, member);
-        return new MemberInfoResponse(
-                member.getId(),
-                member.getName(),
-                member.getEmail(),
-                member.getPhotoUrl(),
-                member.getProfile().getContent(),
-                isFollowingResponse);
+//        Member member = memberRepository.findByEmail(finalEmail)
+//                .orElseThrow(() -> new IllegalArgumentException("not found: " + finalEmail));
+        Optional<Member> member = memberRepository.findByEmail(finalEmail);
+        if(member.isPresent()) {
+            boolean isFollowingResponse = isFollowing(authentication, member.get());
+            return new MemberInfoResponse(
+                    member.get().getId(),
+                    member.get().getName(),
+                    member.get().getEmail(),
+                    member.get().getPhotoUrl(),
+                    member.get().getProfile().getContent(),
+                    isFollowingResponse);
+        } else {
+            return null;
+        }
     }
 
     public boolean isFollowing(Authentication authentication, Member findMember) {

--- a/src/main/java/com/likelion/hufsting/domain/follow/service/FollowService.java
+++ b/src/main/java/com/likelion/hufsting/domain/follow/service/FollowService.java
@@ -42,6 +42,9 @@ public class FollowService {
         if (!followMember.isPresent()) {
             throw new MemberRequestException("회원정보를 찾을 수 없습니다.");
         }
+        if (!followeeMember.isPresent()) {
+            throw new MemberRequestException("검색한 회원은 존재하지 않습니다.");
+        }
 
         if (followMember.isPresent()) {
             //추가 기능(언팔로우)


### PR DESCRIPTION
사용자 없을때 예외처리 대신 null 값 보내서 401 403 에러 발생 하지 않고 아무값도 안 보내게 하기